### PR TITLE
Add about page

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import Sidebar, { Transcript } from "@/components/Sidebar";
+import { useUser } from "@clerk/nextjs";
+import Link from "next/link";
+
+export default function AboutPage() {
+  const { isSignedIn } = useUser();
+  const [transcripts, setTranscripts] = useState<Transcript[]>([]);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (isSignedIn) {
+      fetch("/api/transcripts")
+        .then((res) => {
+          if (!res.ok) throw new Error("AUTH_ERROR");
+          return res.json();
+        })
+        .then((data) => setTranscripts(data.transcripts))
+        .catch((err) => {
+          console.error(err);
+          setError("Er is iets misgegaan bij het ophalen van je transcripts.");
+        });
+    }
+  }, [isSignedIn]);
+
+  return (
+    <div className="bg-gray-50 min-h-screen">
+      <div className="flex h-screen">
+        <Sidebar transcripts={transcripts} />
+        <div className="flex-1 overflow-y-auto">
+          <div className="container mx-auto px-4 py-12 max-w-4xl">
+            <h1 className="text-4xl font-bold mb-6 text-gray-800">Over Luisterslim</h1>
+            <p className="mb-4 text-gray-700">
+              Luisterslim helpt je audio-opnames om te zetten in duidelijke notulen. Upload
+              een bestand en ontvang automatisch een volledig transcript met samenvatting en actiepunten.
+            </p>
+
+            <h2 className="text-2xl font-semibold mt-8 mb-4 text-gray-800">Functionaliteiten</h2>
+            <ul className="list-disc list-inside space-y-2 text-gray-700">
+              <li>Ondersteuning voor mp3, mp4, wav en andere formaten</li>
+              <li>Automatisch transcript en samenvatting</li>
+              <li>Actiepunten en vraag-&amp;antwoord detectie</li>
+              <li>Woordfrequentie-overzicht en export naar Word</li>
+              <li>Bewaar notulen veilig in je account</li>
+            </ul>
+
+            <h2 className="text-2xl font-semibold mt-8 mb-4 text-gray-800">Privacy &amp; Veiligheid</h2>
+            <p className="mb-4 text-gray-700">
+              Wij verwerken je audio veilig en verwijderen bestanden direct na het transcriberen.
+              Je transcripts worden opgeslagen in onze beveiligde database en worden nooit gedeeld.
+            </p>
+            <div className="mt-6 flex justify-center">
+              <div className="w-32 h-32 bg-blue-100 rounded-full animate-pulse"></div>
+            </div>
+            {error && <p className="text-red-600 mt-4 text-center">{error}</p>}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import { stopwords } from "./stopwords"; // adjust path as needed
 import Sidebar, { Transcript } from "../components/Sidebar";
 import ResultsSection from "@/components/ResultsSection";
 import Swal from 'sweetalert2';
+import Link from "next/link";
 import { useUser, useClerk, SignedOut, SignedIn } from "@clerk/nextjs";
 
 interface QnaItem {
@@ -413,6 +414,14 @@ export default function Home() {
           <p className="text-gray-600">
           Upload een mp3, mp4, mpeg, mpga, m4a, wav of webm bestand
           </p>
+          <div className="mt-4">
+            <Link
+              href="/about"
+              className="inline-block px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+            >
+              Over deze applicatie
+            </Link>
+          </div>
         </div>
   {/* Transcription Model Dropdown */}
   

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -400,7 +400,14 @@ export default function Home() {
 
 {<Sidebar transcripts={transcripts} />}
 <div className="flex-1 overflow-y-auto">
-
+<div className="mt-4 flex justify-end mr-10">
+    <Link
+      href="/about"
+      className="inline-block px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+    >
+      Informatie over de applicatie
+    </Link>
+  </div>
       <div className="container mx-auto px-4 py-12 max-w-4xl">
 
         {/* New controls row: model selector and summarization toggle */}
@@ -414,14 +421,7 @@ export default function Home() {
           <p className="text-gray-600">
           Upload een mp3, mp4, mpeg, mpga, m4a, wav of webm bestand
           </p>
-          <div className="mt-4">
-            <Link
-              href="/about"
-              className="inline-block px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
-            >
-              Over deze applicatie
-            </Link>
-          </div>
+          
         </div>
   {/* Transcription Model Dropdown */}
   

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -161,9 +161,7 @@ export default function Sidebar({ transcripts }: SidebarProps) {
               <div className="text-xs text-indigo-300">Free Plan</div>
             </div>
             <div className="flex justify-between text-xs">
-              <button className="text-indigo-300 hover:text-white">
-                <FaCog className="inline mr-1" /> Instellingen
-              </button>
+              
               <button
                 onClick={() => signOut()}
                 className="text-indigo-300 hover:text-white"


### PR DESCRIPTION
## Summary
- create an `/about` page to showcase the application and mention privacy
- link to the About page from the home page

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68552210fc908333a37a97356a499264